### PR TITLE
Don't print message about data_length with b'CLSE' command

### DIFF
--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -258,7 +258,7 @@ class AdbMessage(object):
             data = bytearray()
             while data_length > 0:
                 temp = usb.BulkRead(data_length, timeout_ms)
-                if len(temp) != data_length:
+                if len(temp) != data_length and command != b'CLSE':
                     print(
                         "Data_length {} does not match actual number of bytes read: {}".format(data_length, len(temp)))
                 data += temp


### PR DESCRIPTION
I think this is necessary to prevent the message

```python
"Data_length {} does not match actual number of bytes read: {}".format(data_length, len(temp))
```

from getting printed when multiple CLOSE commands are sent. 